### PR TITLE
Install splitweb

### DIFF
--- a/tiddlywiki-plugin/Makefile
+++ b/tiddlywiki-plugin/Makefile
@@ -19,7 +19,7 @@ serve: build check-env
 
 .PHONY: build
 # target: build - compile site content
-build: check-env
+build: check-env deps
 	@node $(TW_TOOL) editions/demo --verbose \
 		--output `pwd`/output --build splitweb
 
@@ -45,3 +45,10 @@ endif
 
 site:
 	@git worktree add --track -b gh-pages $@ origin/gh-pages
+
+.PHONY: deps
+# target: deps - download dependencies
+deps: plugins/iilyak/splitweb
+
+plugins/iilyak/splitweb:
+	@git clone https://github.com/iilyak/tiddlywiki-splitweb.git $@

--- a/tiddlywiki-plugin/init_template.ffizer.hbs
+++ b/tiddlywiki-plugin/init_template.ffizer.hbs
@@ -8,6 +8,6 @@ echo 'now you should have two files `gh-pages.pub` and `gh-pages`'
 echo '==> go to Repository Settings'
 echo '==>  * Go to Deploy Keys and add your public key with the Allow write access'
 echo '==>  * Go to Secrets and add your private key as ACTIONS_DEPLOY_KEY'
-echo '*** Don't forget to remove `gh-pages.pub` and `gh-pages`'
+echo '*** Remove `gh-pages.pub` and `gh-pages`'
 echo 'rm gh-pages.pub gh-pages'
 {{~ /if }}

--- a/tiddlywiki-plugin/init_template.ffizer.hbs
+++ b/tiddlywiki-plugin/init_template.ffizer.hbs
@@ -1,6 +1,8 @@
 #!/bin/bash
 {{ #if (str_to_json(repo_init)) ~}}
 git init
+git add .gitignore
+git commit -m "initial version"
 git worktree add --track -b gh-pages site origin/gh-pages
 echo creating deployment key
 ssh-keygen -t rsa -b 4096 -C "$(git config user.email)" -f gh-pages -N ""


### PR DESCRIPTION
The generated plugin missing splitweb. This PR adds a simple installer to download the missing plugin.